### PR TITLE
minizinc: do not remove comments if not rewrapping

### DIFF
--- a/pymzn/mzn/minizinc.py
+++ b/pymzn/mzn/minizinc.py
@@ -205,11 +205,6 @@ def preprocess_model(model, rewrap=True, **kwargs):
 
     if rewrap:
         model = rewrap_model(model)
-    else:
-        block_comm_p = re.compile('/\*.*\*/', re.DOTALL)
-        model = block_comm_p.sub('', model)
-        line_comm_p = re.compile('%.*')
-        model = line_comm_p.sub('', model)
 
     return model
 


### PR DESCRIPTION
Blindly removing comments with regexes messes up with strings.
Fixes Github issue #34